### PR TITLE
#23 - Added TMPDIR env variable to the yum environment.

### DIFF
--- a/yum-plugin/src/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMap.java
+++ b/yum-plugin/src/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMap.java
@@ -16,8 +16,6 @@
 
 package com.tw.go.plugin.material.artifactrepository.yum.exec;
 
-import org.apache.commons.codec.digest.DigestUtils;
-
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +56,7 @@ public class YumEnvironmentMap {
     }
 
     private String getTempRepoFilePath() {
-        File temporaryRepoFileLocation = new File(getSystemPropertyValueFor("go.yum.tmpdir", defaultTempYumRepoDir), String.format("go-yum-plugin-%s", DigestUtils.md5Hex(packageRepoId)));
+        File temporaryRepoFileLocation = new File(getSystemPropertyValueFor("go.yum.tmpdir", defaultTempYumRepoDir), String.format("go-yum-plugin-%s", packageRepoId));
         temporaryRepoFileLocation.mkdirs();
         return temporaryRepoFileLocation.getAbsolutePath();
     }

--- a/yum-plugin/src/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMap.java
+++ b/yum-plugin/src/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMap.java
@@ -1,0 +1,65 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.tw.go.plugin.material.artifactrepository.yum.exec;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class YumEnvironmentMap {
+
+    final String defaultTempYumRepoDir = "/var/tmp";
+    final String HOME = "HOME";
+    final String TMPDIR = "TMPDIR";
+    private String packageRepoId;
+
+    public YumEnvironmentMap(String packageRepoId) {
+        this.packageRepoId = packageRepoId;
+    }
+
+    public Map<String, String> buildYumEnvironmentMap() {
+        Map<String, String> envMap = new HashMap<String, String>();
+
+        envMap.put(HOME, getHomeEnvVarValue());
+        envMap.put(TMPDIR, getTempRepoFilePath());
+        return envMap;
+    }
+
+    String getSystemEnvVariableFor(String name) {
+        return System.getenv(name);
+    }
+
+    String getSystemPropertyValueFor(String name, String defaultValue) {
+        return System.getProperty(name, defaultValue);
+    }
+
+    private String getHomeEnvVarValue() {
+        String homeEnv = getSystemEnvVariableFor(HOME);
+        if (homeEnv == null) {
+            homeEnv = getSystemPropertyValueFor("java.io.tmpdir", null);
+        }
+        return homeEnv;
+    }
+
+    private String getTempRepoFilePath() {
+        File temporaryRepoFileLocation = new File(getSystemPropertyValueFor("go.yum.tmpdir", defaultTempYumRepoDir), String.format("go-yum-plugin-%s", DigestUtils.md5Hex(packageRepoId)));
+        temporaryRepoFileLocation.mkdirs();
+        return temporaryRepoFileLocation.getAbsolutePath();
+    }
+}

--- a/yum-plugin/src/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommand.java
+++ b/yum-plugin/src/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommand.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMapTest.java
+++ b/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMapTest.java
@@ -1,0 +1,65 @@
+package com.tw.go.plugin.material.artifactrepository.yum.exec;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.containsString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class YumEnvironmentMapTest {
+    @Test
+    public void shouldSetHomeEnvToTempWhenDefaultHomeEnvValueIsNotSet() throws Exception {
+        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+        YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
+        expectedEnvMap.put(yumEnvironmentMap.HOME, System.getProperty("java.io.tmpdir"));
+        doReturn(null).when(yumEnvironmentMap).getSystemEnvVariableFor(yumEnvironmentMap.HOME);
+
+        Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
+
+        assertThat(actualEnvMap.get(yumEnvironmentMap.HOME), is(expectedEnvMap.get(yumEnvironmentMap.HOME)));
+    }
+
+    @Test
+    public void shouldSetYumHomeEnvToTheHomeEnvVarValueAndNotDefaultWhenHOMEEnvVarIsSet() throws Exception {
+        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+        YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
+        expectedEnvMap.put(yumEnvironmentMap.HOME, System.getProperty("java.io.tmpdir"));
+        doReturn("/Users/Ali").when(yumEnvironmentMap).getSystemEnvVariableFor(yumEnvironmentMap.HOME);
+
+        Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
+
+        assertThat(actualEnvMap.get(yumEnvironmentMap.HOME), is(not(expectedEnvMap.get(yumEnvironmentMap.HOME))));
+        assertThat(actualEnvMap.get(yumEnvironmentMap.HOME), is("/Users/Ali"));
+    }
+
+    @Test
+    public void shouldSetVarTmpAsDefaultTempLocationForYumIfEnvGoYumTmpdirIsNotSpecified() throws Exception {
+        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+        YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
+        expectedEnvMap.put(yumEnvironmentMap.TMPDIR, yumEnvironmentMap.defaultTempYumRepoDir);
+        doReturn(null).when(yumEnvironmentMap).getSystemEnvVariableFor("go.yum.tmpdir");
+
+        Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
+
+        assertThat(actualEnvMap.get(yumEnvironmentMap.TMPDIR), containsString(expectedEnvMap.get(yumEnvironmentMap.TMPDIR)));
+    }
+
+    @Test
+    public void shouldSetTempLocationForYumToTheDirectorySpecifiedBySystemProperty() throws Exception {
+        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+        YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
+        expectedEnvMap.put(yumEnvironmentMap.TMPDIR, yumEnvironmentMap.defaultTempYumRepoDir);
+        doReturn("some/location").when(yumEnvironmentMap).getSystemPropertyValueFor("go.yum.tmpdir", yumEnvironmentMap.defaultTempYumRepoDir);
+
+        Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
+
+        assertThat(actualEnvMap.get(yumEnvironmentMap.TMPDIR), containsString("some/location"));
+        assertThat(actualEnvMap.get(yumEnvironmentMap.TMPDIR), not(containsString(expectedEnvMap.get(yumEnvironmentMap.TMPDIR))));
+    }
+}

--- a/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMapTest.java
+++ b/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMapTest.java
@@ -1,3 +1,19 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
 package com.tw.go.plugin.material.artifactrepository.yum.exec;
 
 import org.junit.Test;

--- a/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
+++ b/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
+++ b/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
@@ -94,26 +94,6 @@ public class RepoQueryCommandTest {
     }
 
     @Test
-    public void shouldSetHomeEnvToTempWhenDefaultHomeEnvIsMissing() throws Exception {
-        Map<String, String> expectedEnvMap = new HashMap<String, String>();
-        expectedEnvMap.put("HOME", System.getProperty("java.io.tmpdir"));
-
-        ArrayList<String> stdOut = new ArrayList<String>();
-        long time = 5;
-        stdOut.add(repoQueryOutput(time, "packager", "http://location", "http://jenkins.job", "ca.hostname"));
-
-        ProcessRunner processRunner = mock(ProcessRunner.class);
-        when(processRunner.execute(any(String[].class), eq(expectedEnvMap))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
-
-        RepoQueryCommand repoQueryCommand = spy(new RepoQueryCommand(processRunner, new RepoQueryParams("repoid", new RepoUrl("http://repourl", null, null), "pkg-spec")));
-        doReturn(null).when(repoQueryCommand).getSystemEnvVariableFor("HOME");
-
-        repoQueryCommand.execute();
-
-        verify(processRunner).execute(any(String[].class), eq(expectedEnvMap));
-    }
-
-    @Test
     public void shouldThrowExceptionIfCommandFails() {
         ProcessRunner processRunner = mock(ProcessRunner.class);
         ArrayList<String> stdErr = new ArrayList<String>();

--- a/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
+++ b/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
@@ -21,6 +21,7 @@ import com.tw.go.plugin.material.artifactrepository.yum.exec.Constants;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.RepoUrl;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.RepoqueryCacheCleaner;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.PackageRevisionMessage;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +57,7 @@ public class RepoQueryCommandTest {
         ArrayList<String> stdOut = new ArrayList<String>();
         long time = 5;
         stdOut.add(repoQueryOutput(time, "packager", "http://location", "http://jenkins.job", "ca.hostname"));
-        when(processRunner.execute(expectedCommand, envMapWithDefaultHome())).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, new RepoQueryParams(repoid, new RepoUrl(repourl, null, null), spec)).execute();
 
         assertThat(packageRevision.getRevision(), is("name-version-release.arch"));
@@ -65,7 +66,7 @@ public class RepoQueryCommandTest {
         assertThat(packageRevision.getData().get(Constants.PACKAGE_LOCATION), is("http://location"));
         assertThat(packageRevision.getTrackbackUrl(), is("http://jenkins.job"));
         assertThat(packageRevision.getRevisionComment(), is("Built on ca.hostname"));
-        verify(processRunner).execute(expectedCommand, envMapWithDefaultHome());
+        verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
     @Test
@@ -81,7 +82,7 @@ public class RepoQueryCommandTest {
         long time = 5;
         stdOut.add(repoQueryOutput(time, "None", "NONE", "NOne", "none"));
 
-        when(processRunner.execute(expectedCommand, envMapWithDefaultHome())).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, new RepoQueryParams(repoid, new RepoUrl(repourl, null, null), spec)).execute();
 
         assertThat(packageRevision.getRevision(), is("name-version-release.arch"));
@@ -90,7 +91,7 @@ public class RepoQueryCommandTest {
         assertThat(packageRevision.getData().get(Constants.PACKAGE_LOCATION), is(nullValue()));
         assertThat(packageRevision.getTrackbackUrl(), is(nullValue()));
         assertThat(packageRevision.getRevisionComment(), is(nullValue()));
-        verify(processRunner).execute(expectedCommand, envMapWithDefaultHome());
+        verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
     @Test
@@ -119,11 +120,11 @@ public class RepoQueryCommandTest {
         ArrayList<String> stdOut = new ArrayList<String>();
         long time = 5;
         stdOut.add(repoQueryOutput(time, "packager", "http://location", "http://jenkins.job", "ca.hostname"));
-        when(processRunner.execute(expectedCommand, envMapWithDefaultHome())).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, "username", "!4321abcd"), spec);
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, params).execute();
         assertThat(packageRevision, is(not(nullValue())));
-        verify(processRunner).execute(expectedCommand, envMapWithDefaultHome());
+        verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
     @Test
@@ -139,11 +140,11 @@ public class RepoQueryCommandTest {
         long time = 5;
         stdOut.add(repoQueryOutput(time, "packager", "http://foo.com/bar", "http://jenkins.job", "ca.hostname"));
 
-        when(processRunner.execute(expectedCommand, envMapWithDefaultHome())).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, "username", "!4321abcd"), spec);
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, params).execute();
         assertThat(packageRevision.getData().get(Constants.PACKAGE_LOCATION), is("http://foo.com/bar"));
-        verify(processRunner).execute(expectedCommand, envMapWithDefaultHome());
+        verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
     @Test
@@ -162,14 +163,14 @@ public class RepoQueryCommandTest {
                 + DELIMITER + "trackback" + DELIMITER + "revision Comment");
         stdOut.add("getPackage/go-agent-13.1.0-13422.x86_64.rpm" + DELIMITER + "go-agent" + DELIMITER + "13.1.0" + DELIMITER + "13422" + DELIMITER + "x86_64" + DELIMITER + time + DELIMITER + "packager" +
                 DELIMITER + "http://foo.com/bar" + DELIMITER + "trackback" + DELIMITER + "revision Comment");
-        when(processRunner.execute(expectedCommand, envMapWithDefaultHome())).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, "username", "!4321abcd"), spec);
         try {
             new RepoQueryCommand(processRunner, params).execute();
             fail("expected failure");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString("Given Package Spec (go-agent) resolves to more than one file on the repository: go-agent-13.1.0-13422.noarch.rpm, go-agent-13.1.0-13422.x86_64.rpm"));
-            verify(processRunner).execute(expectedCommand, envMapWithDefaultHome());
+            verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
         }
     }
 
@@ -212,9 +213,10 @@ public class RepoQueryCommandTest {
                 "%{RELATIVEPATH}" + DELIMITER + "%{NAME}" + DELIMITER + "%{VERSION}" + DELIMITER + "%{RELEASE}" + DELIMITER + "%{ARCH}" + DELIMITER + "%{BUILDTIME}" + DELIMITER + "%{PACKAGER}" + DELIMITER + "%{LOCATION}" + DELIMITER + "%{URL}" + DELIMITER + "%{BUILDHOST}"};
     }
 
-    private Map<String, String> envMapWithDefaultHome() {
+    private Map<String, String> envMapWithDefaultValues(String repoid) {
         Map<String, String> expectedEnvMap = new HashMap<String, String>();
         expectedEnvMap.put("HOME", System.getenv("HOME"));
+        expectedEnvMap.put("TMPDIR", String.format("/var/tmp/go-yum-plugin-%s", DigestUtils.md5Hex(repoid)));
         return expectedEnvMap;
     }
 


### PR DESCRIPTION
* Yum's repoquery used to happen in the same folder for all the repositories, resulting in yum pid lock errors.
* With this change repoquery will happen in different folders for different repositories.
* By default this temporary location is /var/tmp. This location can be overwritten by setting the environment for go.yum.tmpdir