### PR TITLE
Cleaning up yum cache folder as part of test teardown

### DIFF
--- a/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/RepoqueryCacheCleaner.java
+++ b/yum-plugin/test/com/tw/go/plugin/material/artifactrepository/yum/exec/RepoqueryCacheCleaner.java
@@ -26,8 +26,7 @@ public class RepoqueryCacheCleaner{
     public static void performCleanup() throws IOException {
         File[] cacheFiles = new File("/var/tmp/").listFiles(new FilenameFilter() {
             public boolean accept(File dir, String name) {
-                String currentUser = System.getProperty("user.name") != null ? System.getProperty("user.name") : "go";
-                return name.startsWith(String.format("yum-%s-", currentUser));
+                return name.startsWith("go-yum-plugin-");
             }
         });
         for(File cacheFile : cacheFiles){


### PR DESCRIPTION
Yum cache folder name was updated as a part of https://github.com/gocd/go-plugins/pull/25, after that cache cleanup on agent machines wasn't happening as a part of test teardown